### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/Marketing-Site/script.js
+++ b/Marketing-Site/script.js
@@ -619,13 +619,38 @@ function updateFormatInfo(platformKey) {
 }
 
 // Download selected format from dropdown
+function sanitizeDownloadUrl(url) {
+    if (typeof url !== 'string' || url.trim() === '') {
+        return null;
+    }
+
+    try {
+        const parsed = new URL(url, window.location.origin);
+        const isHttp = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        const isRelative = !/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+
+        if (isHttp || isRelative) {
+            return parsed.href;
+        }
+    } catch (e) {
+        return null;
+    }
+
+    return null;
+}
+
 function downloadSelectedFormat(platformKey, defaultUrl) {
     const select = document.getElementById(`format-select-${platformKey}`);
-    const downloadUrl = select ? select.value : defaultUrl;
+    const selectedUrl = select ? select.value : defaultUrl;
+    const safeUrl = sanitizeDownloadUrl(selectedUrl) || sanitizeDownloadUrl(defaultUrl);
+
+    if (!safeUrl) {
+        return;
+    }
     
     // Create temporary link and trigger download
     const link = document.createElement('a');
-    link.href = downloadUrl;
+    link.href = safeUrl;
     link.download = '';
     document.body.appendChild(link);
     link.click();

--- a/Marketing-Site/script.js
+++ b/Marketing-Site/script.js
@@ -620,14 +620,19 @@ function updateFormatInfo(platformKey) {
 
 // Download selected format from dropdown
 function sanitizeDownloadUrl(url) {
-    if (typeof url !== 'string' || url.trim() === '') {
+    if (typeof url !== 'string') {
+        return null;
+    }
+
+    const trimmed = url.trim();
+    if (trimmed === '') {
         return null;
     }
 
     try {
-        const parsed = new URL(url, window.location.origin);
+        const parsed = new URL(trimmed, window.location.origin);
         const isHttp = parsed.protocol === 'http:' || parsed.protocol === 'https:';
-        const isRelative = !/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+        const isRelative = !/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed);
 
         if (isHttp || isRelative) {
             return parsed.href;


### PR DESCRIPTION
Potential fix for [https://github.com/imnexerio/revix/security/code-scanning/5](https://github.com/imnexerio/revix/security/code-scanning/5)

The safest fix is to **validate and constrain `downloadUrl` before use**. Keep existing behavior, but only allow:
1. Relative URLs, or  
2. Absolute `http:` / `https:` URLs.

Reject everything else (e.g., `javascript:`, `data:`, malformed URLs), and fall back to `defaultUrl` only if it passes the same validation.

In `Marketing-Site/script.js`, update `downloadSelectedFormat` to sanitize the selected/default URL through a helper function, then use only the sanitized value for `link.href`. Add a small helper (e.g., `sanitizeDownloadUrl`) in the same file near the download logic. No external packages are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
